### PR TITLE
Install build-essentials so that cmake and compilers can be used

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ LABEL "repository"="https://github.com/m0nhawk/conda-package-publish-action"
 LABEL "maintainer"="Andrew Prokhorenkov <andrew.prokhorenkov@gmail.com>"
 
 RUN conda install -y anaconda-client conda-build
-RUN conda install -c anaconda make
 RUN apt-get update 
 RUN apt-get install -y build-essential --fix-missing
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ LABEL "repository"="https://github.com/m0nhawk/conda-package-publish-action"
 LABEL "maintainer"="Andrew Prokhorenkov <andrew.prokhorenkov@gmail.com>"
 
 RUN conda install -y anaconda-client conda-build
+RUN conda install -c anaconda make
+RUN apt-get update 
+RUN apt-get install -y build-essential --fix-missing
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,12 @@ inputs:
   publish:
     description: 'Whether to publish to anaconda'
     default: '{false}'
+  convert_win:
+    description: 'Whether to convert linux build for windows'
+    default: '{true}'
+  convert_osx:
+    description: 'Whether to convert linux build for osx'
+    default: '{true}'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,15 +18,23 @@ check_if_meta_yaml_file_exists() {
 
 build_package(){
     eval conda build "-c "${INPUT_CHANNELS} --output-folder . .
-    conda convert -p osx-64 linux-64/*.tar.bz2
-    conda convert -p win-64 linux-64/*.tar.bz2
+    if [ $INPUT_CONVERT_OSX = true ]; then
+        conda convert -p osx-64 linux-64/*.tar.bz2
+    fi
+    if [ $INPUT_CONVERT_WIN = true ]; then
+        conda convert -p win-64 linux-64/*.tar.bz2
+    fi
 }
 
 upload_package(){
     export ANACONDA_API_TOKEN=$INPUT_ANACONDATOKEN
     anaconda upload --label main linux-64/*.tar.bz2
-    anaconda upload --label main osx-64/*.tar.bz2
-    anaconda upload --label main win-64/*.tar.bz2
+    if [ $INPUT_CONVERT_OSX = true ]; then
+        anaconda upload --label main osx-64/*.tar.bz2
+    fi
+    if [ $INPUT_CONVERT_WIN = true ]; then
+        anaconda upload --label main win-64/*.tar.bz2
+    fi
 }
 
 go_to_build_dir


### PR DESCRIPTION
Installs make and compilers in the docker image so that we can use cmake to build the dvc exe.
Adds variables to make converting the conda build to windows and mac optional.