### PR TITLE
Fix issues with test_package

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,9 @@ inputs:
   convert_osx:
     description: 'Whether to convert linux build for osx'
     default: 'true'
+  build_all:
+    description: 'Whether to build all variants'
+    default: 'false'
   test_all:
     description: 'Whether to build and test all recipe variants'
     default: 'false'

--- a/action.yml
+++ b/action.yml
@@ -22,9 +22,6 @@ inputs:
   convert_osx:
     description: 'Whether to convert linux build for osx'
     default: 'true'
-  build_all:
-    description: 'Whether to build all variants'
-    default: 'false'
   test_all:
     description: 'Whether to build and test all recipe variants'
     default: 'false'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,13 +39,6 @@ build_and_test_package(){
 test_package(){
     # builds and tests one package
     eval conda build "-c "${INPUT_CHANNELS} "--python="${INPUT_TEST_PYVER} "--numpy="${INPUT_TEST_NPVER} --output-folder . .
-    if [ ${INPUT_CONVERT_OSX} = true ]; then
-        conda convert -p osx-64 linux-64/*.tar.bz2
-    fi
-    if [ ${INPUT_CONVERT_WIN} = true ]; then
-        conda convert -p win-64 linux-64/*.tar.bz2
-    fi
-
 }
 
 upload_package(){

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,6 +39,12 @@ build_and_test_package(){
 test_package(){
     # builds and tests one package
     eval conda build "-c "${INPUT_CHANNELS} "--python="${INPUT_TEST_PYVER} "--numpy="${INPUT_TEST_NPVER} --output-folder . .
+    if [ ${INPUT_CONVERT_OSX} = true ]; then
+        conda convert -p osx-64 linux-64/*.tar.bz2
+    fi
+    if [ ${INPUT_CONVERT_WIN} = true ]; then
+        conda convert -p win-64 linux-64/*.tar.bz2
+    fi
 
 }
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,7 +38,7 @@ build_and_test_package(){
 
 test_package(){
     # builds and tests one package
-    eval conda build "-c "${INPUT_CHANNELS} "--python="${INPUT_TEST_PYVER} "--numpy="${INPUT_TEST_NPVER} .
+    eval conda build "-c "${INPUT_CHANNELS} "--python="${INPUT_TEST_PYVER} "--numpy="${INPUT_TEST_NPVER} --output-folder . .
 
 }
 


### PR DESCRIPTION
- There were issues with publishing to conda when only building with `test_package`, because the build files could not be found. Resolved by setting output folder in `test_package`
- By default we do not build all variants, just one, and it only builds for linux. If we set publish to True, it is expecting to upload a macos and windows version because convert_win and convert_osx are set to True by default, and so we get an error. Therefore I have changed the behaviour of test_package to convert to mac and win if these vars are set to True.

Other things we may like to change:
- `test_all` seems like an unclear name, because if it's set to false, not only are not all of the variants tested but not all are built either. 
- `build package` : https://github.com/paskino/conda-package-publish-action/blob/f6b2c3073170a570f0f4b34331cc517acf8cb8f5/entrypoint.sh#L19 is never used. We could have a 'build_all' variable. If 'test_all'=False and 'build_all' = True then it would build all but only test one.

