### PR TITLE
Fixes default publishing behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ When pushing to master *all* variants are built and tested.
 - If an [annotated](https://git-scm.com/book/en/v2/Git-Basics-Tagging) tag is created, all variants are built, tested and published.
 - If opening or modifying a pull request to master, a single variant is built and tested, but not published.
 - Builds using channels: conda-forge, ccpi, and paskino.
-- Builds for linux and conda converts to windows and macOS as well, in the case that all variants are being built.
+- Builds for linux and conda converts to windows and macOS as well.
 
 ```yaml
 name: conda_build
@@ -49,6 +49,8 @@ jobs:
         AnacondaToken: ${{ secrets.ANACONDA_TOKEN }}
         publish: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') }}
         test_all: ${{(github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')) || (github.ref == 'refs/heads/master')}}
+        convert_win: true
+        convert_osx: true
 ```
 
 ### Example project structure

--- a/action.yml
+++ b/action.yml
@@ -18,10 +18,10 @@ inputs:
     default: 'false'
   convert_win:
     description: 'Whether to convert linux build for windows'
-    default: 'true'
+    default: 'false'
   convert_osx:
     description: 'Whether to convert linux build for osx'
-    default: 'true'
+    default: 'false'
   test_all:
     description: 'Whether to build and test all recipe variants'
     default: 'false'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -45,9 +45,15 @@ upload_package(){
     export ANACONDA_API_TOKEN=$INPUT_ANACONDATOKEN
     anaconda upload --label main linux-64/*.tar.bz2
     if [ ${INPUT_CONVERT_OSX} = true ]; then
+        if [ ${INPUT_TEST_ALL} = false ]; then
+            conda convert -p osx-64 linux-64/*.tar.bz2
+        fi
         anaconda upload --label main osx-64/*.tar.bz2
     fi
     if [ ${INPUT_CONVERT_WIN} = true ]; then
+        if [ ${INPUT_TEST_ALL} = false ]; then
+            conda convert -p win-64 linux-64/*.tar.bz2
+        fi
         anaconda upload --label main win-64/*.tar.bz2
     fi
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,59 +16,43 @@ check_if_meta_yaml_file_exists() {
     fi
 }
 
-build_package(){
-    eval conda build "-c "${INPUT_CHANNELS} --output-folder . . --no-test
-    if [ ${INPUT_CONVERT_OSX} = true ]; then
-        conda convert -p osx-64 linux-64/*.tar.bz2
-    fi
-    if [ ${INPUT_CONVERT_WIN} = true ]; then
-        conda convert -p win-64 linux-64/*.tar.bz2
-    fi
-}
-
 build_and_test_package(){
-    eval conda build "-c "${INPUT_CHANNELS} --output-folder . .
+    if  [ ${INPUT_TEST_ALL} = true ]; then
+        eval conda build "-c "${INPUT_CHANNELS} --output-folder . .
+    else
+        # builds and tests one package, with the specified combination of python and numpy
+        eval conda build "-c "${INPUT_CHANNELS} "--python="${INPUT_TEST_PYVER} "--numpy="${INPUT_TEST_NPVER} --output-folder . .
+    fi
+
     if [ ${INPUT_CONVERT_OSX} = true ]; then
         conda convert -p osx-64 linux-64/*.tar.bz2
     fi
     if [ ${INPUT_CONVERT_WIN} = true ]; then
         conda convert -p win-64 linux-64/*.tar.bz2
     fi
-}
-
-test_package(){
-    # builds and tests one package
-    eval conda build "-c "${INPUT_CHANNELS} "--python="${INPUT_TEST_PYVER} "--numpy="${INPUT_TEST_NPVER} --output-folder . .
 }
 
 upload_package(){
-    export ANACONDA_API_TOKEN=$INPUT_ANACONDATOKEN
-    anaconda upload --label main linux-64/*.tar.bz2
-    if [ ${INPUT_CONVERT_OSX} = true ]; then
-        if [ ${INPUT_TEST_ALL} = false ]; then
-            conda convert -p osx-64 linux-64/*.tar.bz2
+    # upload package if INPUT_PUBLISH is set to true
+    if [ ${INPUT_PUBLISH} = true ]; then
+        export ANACONDA_API_TOKEN=$INPUT_ANACONDATOKEN
+        anaconda upload --label main linux-64/*.tar.bz2
+        if [ ${INPUT_CONVERT_OSX} = true ]; then
+            if [ ${INPUT_TEST_ALL} = false ]; then
+                conda convert -p osx-64 linux-64/*.tar.bz2
+            fi
+            anaconda upload --label main osx-64/*.tar.bz2
         fi
-        anaconda upload --label main osx-64/*.tar.bz2
-    fi
-    if [ ${INPUT_CONVERT_WIN} = true ]; then
-        if [ ${INPUT_TEST_ALL} = false ]; then
-            conda convert -p win-64 linux-64/*.tar.bz2
+        if [ ${INPUT_CONVERT_WIN} = true ]; then
+            if [ ${INPUT_TEST_ALL} = false ]; then
+                conda convert -p win-64 linux-64/*.tar.bz2
+            fi
+            anaconda upload --label main win-64/*.tar.bz2
         fi
-        anaconda upload --label main win-64/*.tar.bz2
     fi
 }
 
 go_to_build_dir
 check_if_meta_yaml_file_exists
-if  [ ${INPUT_TEST_ALL} = true ]; then
-    build_and_test_package
-else
-    # build and test only the specified combination of python and numpy
-    # build_package
-    test_package
-fi
-
-# upload package if INPUT_PUBLISH is set to true
-if [ ${INPUT_PUBLISH} = true ]; then
-    upload_package
-fi
+build_and_test_package
+upload_package


### PR DESCRIPTION
Currently the [default settings](https://github.com/paskino/conda-package-publish-action/blob/7fc64896d8455f98513f1672f52ce1f0b114db35/action.yml#L16) are:
```
convert_osx: True
convert_win: True 
test_all: False
publish: False
```

If all of these settings are kept, except publish is set to True, this causes errors. This is because when `test_all: False`, we run 
[test_package](https://github.com/paskino/conda-package-publish-action/blob/7fc64896d8455f98513f1672f52ce1f0b114db35/entrypoint.sh#L39) instead of [build_and_test_package](https://github.com/paskino/conda-package-publish-action/blob/7fc64896d8455f98513f1672f52ce1f0b114db35/entrypoint.sh#L29). This means we do not convert to win or mac, and then when we go to [upload_package](https://github.com/paskino/conda-package-publish-action/blob/7fc64896d8455f98513f1672f52ce1f0b114db35/entrypoint.sh#L44) it is trying to upload packages that don't exist.

Although in our uses of the action, we wouldn't set `test_all: False` and` publish: True `(we would always have `test_all: True` when `publish: True`) I think it's good to make sure default behaviour doesn't break.

I tested this PR in a [test repository](https://github.com/lauramurgatroyd/test-gh-actions/actions/runs/1117069735) to make sure it works