### PR TITLE
Fix apt-get update command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL "repository"="https://github.com/m0nhawk/conda-package-publish-action"
 LABEL "maintainer"="Andrew Prokhorenkov <andrew.prokhorenkov@gmail.com>"
 
 RUN conda install -y anaconda-client conda-build
-RUN apt-get update 
+RUN apt update 
 RUN apt-get install -y build-essential --fix-missing
 
 COPY entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ LABEL "repository"="https://github.com/m0nhawk/conda-package-publish-action"
 LABEL "maintainer"="Andrew Prokhorenkov <andrew.prokhorenkov@gmail.com>"
 
 RUN conda install -y anaconda-client conda-build
-RUN apt update 
 RUN apt-get install -y build-essential --fix-missing
 
 COPY entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ LABEL "repository"="https://github.com/m0nhawk/conda-package-publish-action"
 LABEL "maintainer"="Andrew Prokhorenkov <andrew.prokhorenkov@gmail.com>"
 
 RUN conda install -y anaconda-client conda-build
+RUN apt-get --allow-releaseinfo-change update
 RUN apt-get install -y build-essential --fix-missing
 
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
The action stopped working due to this error:
```
Step 5/8 : RUN apt-get update
   ---> Running in 46bfa842c612
  Get:1 http://deb.debian.org/debian buster InRelease [122 kB]
  Get:2 http://security.debian.org/debian-security buster/updates InRelease [65.4 kB]
  Get:3 http://deb.debian.org/debian buster-updates InRelease [51.9 kB]
  Reading package lists...
  E: Repository 'http://deb.debian.org/debian buster InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
  E: Repository 'http://deb.debian.org/debian buster-updates InRelease' changed its 'Suite' value from 'stable-updates' to 'oldstable-updates'
  E: Repository 'http://security.debian.org/debian-security buster/updates InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
  The command '/bin/sh -c apt-get update' returned a non-zero code: 100
```

This PR resolves the problem.